### PR TITLE
move INCS to CPPFLAGS; pass CPPFLAGS to CC when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ${PROG}: ${OBJS}
 	${CC} -o $@ ${OBJS} ${LDFLAGS}
 
 .c.o:
-	${CC} ${CFLAGS} -c $<
+	${CC} ${CFLAGS} ${CPPFLAGS} -c $<
 
 clean:
 	-rm ${OBJS} ${PROG}

--- a/config.mk
+++ b/config.mk
@@ -13,8 +13,8 @@ INCS = -I${X11INC}
 LIBS = -L${X11LIB} -lX11
 
 # flags
-CPPFLAGS =
-CFLAGS = -Wall -Wextra ${INCS}
+CPPFLAGS = ${INCS}
+CFLAGS = -Wall -Wextra
 LDFLAGS = ${LIBS}
 
 # compiler and linker


### PR DESCRIPTION
it's a nitpick, but makes `make CFLAGS='-O2 -pipe'` (for e.g. when building from the ports tree) actually work :-)