### PR TITLE
pledge after XOpenDisplay()

### DIFF
--- a/xclickroot.c
+++ b/xclickroot.c
@@ -21,11 +21,6 @@ main(int argc, char *argv[])
 	Display *dpy;
 	Window rootwin;
 
-#if __OpenBSD__
-	if (pledge("unix stdio rpath proc exec", NULL) == -1)
-		err(EXIT_FAILURE, "pledge");
-#endif
-
 	argv++;
 	argc--;
 	button = Button3;
@@ -57,6 +52,16 @@ main(int argc, char *argv[])
 	/* open connection to server and set X variables */
 	if ((dpy = XOpenDisplay(NULL)) == NULL)
 		errx(EXIT_FAILURE, "cannot open display");
+
+#if __OpenBSD__
+	/*
+	 * rpath: xlib needs it at runtime (for e.g. reading the error db)
+	 * proc exec: running the program
+	 */
+	if (pledge("stdio rpath proc exec", NULL) == -1)
+		err(EXIT_FAILURE, "pledge");
+#endif
+
 	rootwin = DefaultRootWindow(dpy);
 	XGrabButton(dpy, button, AnyModifier, rootwin, False, ButtonPressMask,
 	            GrabModeSync, GrabModeSync, None, None);


### PR DESCRIPTION
This allows to drop the "unix rpath" promises.  Also, XOpenDisplay could open sockets too, so in that case "inet" was missing.  It's easier to pledge just once after XOpenDisplay, but if you prefer we can pledge twice.